### PR TITLE
fix(ci): pin github-tag-action to existing v6.2 tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: tag
-        uses: mathieudutour/github-tag-action@v6
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch


### PR DESCRIPTION
The `Release` job failed because `mathieudutour/github-tag-action@v6` does not resolve — the action only publishes `v6.0`/`v6.1`/`v6.2`, not a bare `v6`. Pin to `v6.2` so the auto-release runs.