### PR TITLE
ci(release): only cut a release on terraform changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [master]
+    paths: ['**.tf']
 
 permissions:
   contents: write


### PR DESCRIPTION
Restrict the release trigger to pushes touching `*.tf` files. Previously every push to `master` (including CI/workflow/Renovate-config changes and action digest pins) cut a new module version; now the published version tracks actual terraform changes only.